### PR TITLE
Do not require oslotest for testing

### DIFF
--- a/cotyledon/tests/base.py
+++ b/cotyledon/tests/base.py
@@ -15,9 +15,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from oslotest import base
+from unittest import TestCase
 
 
-class TestCase(base.BaseTestCase):
+class TestCase(TestCase):
 
     """Test case base class for all unit tests."""

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,11 +6,11 @@ hacking<0.11,>=0.10.0
 
 coverage>=3.6
 python-subunit>=0.0.18
-oslotest>=1.10.0 # Apache-2.0
 oslo.config>=3.14.0  # Apache-2.0
 testrepository>=0.0.18
 testscenarios>=0.4
 testtools>=1.4.0
+mock
 os-testr
 
 # docs


### PR DESCRIPTION
There are no specific oslotest features needed and given that this
module should be useful outside of the OpenStack world, remove the
oslotest test-requirement.