### PR TITLE
Windows support workaround

### DIFF
--- a/cotyledon/_service.py
+++ b/cotyledon/_service.py
@@ -165,7 +165,8 @@ class ServiceWorker(_utils.SignalManager):
                  started_hooks, graceful_shutdown_timeout):
         super(ServiceWorker, self).__init__()
         self._ready = threading.Event()
-        _utils.spawn(self._watch_parent_process, parent_pipe)
+        if parent_pipe is not None:
+            _utils.spawn(self._watch_parent_process, parent_pipe)
 
         # Reseed random number generator
         random.seed()


### PR DESCRIPTION
On Windows, avoid creating subprocesses unless really needed.
Forking is out of the question and "multiprocessing" may not help
either as service objects aren't usually picklable.

This change will allow running ceilometer on Windows.