### PR TITLE
Stop hiding the number of custom signals

### DIFF
--- a/cotyledon/_utils.py
+++ b/cotyledon/_utils.py
@@ -34,7 +34,7 @@ _SIGNAL_TO_NAME = dict((getattr(signal, name), name) for name in dir(signal)
 
 
 def signal_to_name(sig):
-    return _SIGNAL_TO_NAME.get(sig)
+    return _SIGNAL_TO_NAME.get(sig, sig)
 
 
 def spawn(target, *args, **kwargs):


### PR DESCRIPTION
And avoid "Child XXX was killed by signal None"

Cf
https://github.com/sileht/cotyledon/blob/bcc34b6883f921e10689ad0cb4d734e4ac4cbfaf/cotyledon/_service_manager.py#L343-L345