### PR TITLE
Ignore non-signal items in signal module

### DIFF
--- a/cotyledon/_utils.py
+++ b/cotyledon/_utils.py
@@ -32,7 +32,7 @@ LOG = logging.getLogger(__name__)
 _SIGNAL_TO_NAME = {
     getattr(signal, name): name
     for name in dir(signal)
-    if name.startswith("SIG") and name not in {"SIG_DFL", "SIG_IGN"}
+    if name.startswith("SIG") and isinstance(getattr(signal, name), signal.Signals)
 }
 
 


### PR DESCRIPTION
There are a few more items such as SIG_UNBLOCK in signal modules which does not represent actual signal.

Ignore such ones to fix wrong signal name mentioned in a log.

This follows what was implemented recently in oslo.service by [1].

[1] https://review.opendev.org/c/openstack/oslo.service/+/945093
