### PR TITLE
Bump lower python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 license = "Apache-2.0"
 dynamic = ["version"]
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 dependencies = [
   "setproctitle; sys_platform != 'win32'",
   "typing_extensions",


### PR DESCRIPTION
Support for Python 3.9 was already removed by [1]. Bump the min lower bound to enforce usage of Python >= 3.10 .

[1] 82b8811f2c976b1cdd814bb637c5412dc776a6b1