### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,12 +33,12 @@ jobs:
             target: mypy
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Python 🔧
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.version }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,8 @@ jobs:
             target: py312
           - version: "3.13"
             target: py313
+          - version: "3.14"
+            target: py314
           - version: "3.13"
             target: pep8
           - version: "3.10"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: actions/setup-python@v5.6.0
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
    "Programming Language :: Python :: 3.11",
    "Programming Language :: Python :: 3.12",
    "Programming Language :: Python :: 3.13",
+   "Programming Language :: Python :: 3.14",
 ]
 license = "Apache-2.0"
 dynamic = ["version"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310,py311,py312,py313,pep8,mypy
+envlist = py310,py311,py312,py313,py314,pep8,mypy
 minversion = 4.0
 skipsdist = true
 


### PR DESCRIPTION
Python 3.14 was released some time ago and is the default version in Ubuntu 26.04 .
Declare support for the version and also add the relevant unit test coverage.